### PR TITLE
Add logEnabled option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ exports.handler = thundraWarmupWrapper((event, context, callback) => {
 });
 ```
 
+And disable `console.log` output.
+
+```js
+const thundraWarmup = require("@thundra/warmup");
+
+const thundraWarmupWrapper = thundraWarmup(null, { logEnabled: false });
+
+exports.handler = thundraWarmupWrapper((event, context, callback) => {
+    callback(null, "No more cold starts!");
+});
+```
+
 `context.succeed`, `context.fail`, `context.done` are also supported.
 
 ```js

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 import WarmupHandler from "./warmup-handler";
 
-module.exports = extraCallback => {
+module.exports = (extraCallback, options) => {
     return originalFunction => {
-        const warmupHandler = new WarmupHandler(extraCallback);
+        const warmupHandler = new WarmupHandler(extraCallback, options);
         return async (event, context, callback) => {
             const warmupCallback = typeof callback === "function" ? callback : context.succeed;
             if (!warmupHandler.checkAndHandleWarmupRequest(event, warmupCallback)) {

--- a/src/warmup-handler.js
+++ b/src/warmup-handler.js
@@ -1,6 +1,8 @@
 class WarmupHandler {
-    constructor(extraCallback) {
+    constructor(extraCallback, options) {
         this.extraCallback = extraCallback;
+        options.logEnabled = options.logEnabled === undefined ? true : options.logEnabled;
+        this.options = options;
         this.defaultDelayInMs = 100;
     }
 
@@ -13,8 +15,14 @@ class WarmupHandler {
         }, delayInMs);
     };
 
+    log = (message, optionalParams) => {
+        if (this.options.logEnabled){
+            console.log(message);
+        }
+    }
+
     handleEmptyWarmupRequest = (callback) => {
-        console.log("Thundra Warmup: %d ms delay", this.defaultDelayInMs);
+        this.log("Thundra Warmup: %d ms delay", this.defaultDelayInMs);
         this.setTimeoutEvent(callback, this.defaultDelayInMs);
     };
 
@@ -28,7 +36,7 @@ class WarmupHandler {
                 delayInMs += parseInt(argParts[1]);
         });
 
-        console.log("Thundra Warmup: %d ms delay", delayInMs);
+        this.log("Thundra Warmup: %d ms delay", delayInMs);
         this.setTimeoutEvent(callback, delayInMs);
     };
 


### PR DESCRIPTION
Currently this library prints `hundra Warmup: %d ms delay` for each warm up call which results in a lot of "garbage" sent to our log systems.

To mitigate this, this PR adds an `options.logEnabled` option so clients of this library can disable this output when needed.